### PR TITLE
Fixed: Repeated Tour Display on Every Page Load (#65)

### DIFF
--- a/client/src/Pages/LandingPage.jsx
+++ b/client/src/Pages/LandingPage.jsx
@@ -11,9 +11,17 @@ import FAQAccordion from '../components/FAQAccordion';
 const Home = () => {
   const [showTour, setShowTour] = useState(false);
 
+  const closeTour = () => {
+    localStorage.setItem('hasSeenTour', 'true');
+    setShowTour(false);
+  };
+
+
   useEffect(() => {
     // Always show the tour after DOM is ready
-    setTimeout(() => setShowTour(true), 300);
+    if (!localStorage.getItem("hasSeenTour")){
+      setTimeout(() => setShowTour(true), 300);
+    }
   }, []);
 
   useEffect(() => {
@@ -74,7 +82,7 @@ const Home = () => {
         {/* Remove animated background blobs */}
       </div>
 
-      {showTour && <Tour onClose={() => setShowTour(false)} auto={true} />}
+      {showTour && <Tour onClose={closeTour} auto={true} />}
 
       <style>{`
         .faq-glow {


### PR DESCRIPTION
Hi team 👋

This PR addresses a critical UX flaw where the **introductory tour** was being triggered **every time the page reloaded**, causing unnecessary disruption for users #65.

---

### 🐞 Problem Recap

* The tour guide was **shown repeatedly** on every page load or refresh.
* This led to **frustration**, especially for returning users familiar with the UI.
* It degraded the usefulness and intent of the tour itself.

---

### 🛠 What I’ve Done

* Implemented a **`localStorage` flag** (`hasSeenTour`) to ensure the tour:

  * **Displays only once per user**
  * **Persists across page refreshes and navigation**
* This significantly improves the user experience by eliminating the repetitive popup.
* Also **maintained flexibility** for optionally integrating a "Replay Tour" button in the future, if needed.

---

### 🌟 Outcome

* No more repetitive onboarding experience.
* Tour now behaves like a true **one-time onboarding tool**.
* More polished and professional UX for all users.

---

### 🏷 Labels

* `gssoc2025`
* `level1`
