### PR TITLE
Fix: removed duplicate support email from Contact page 

### DIFF
--- a/client/src/Pages/Contact.jsx
+++ b/client/src/Pages/Contact.jsx
@@ -96,10 +96,7 @@ const Contact = () => {
       {/* Contact Info */}
       <section className="max-w-4xl mx-auto px-6 py-16 text-center" data-aos="fade-up">
         <div className="bg-[#334155] dark:bg-gray-800 rounded-2xl p-8 shadow-lg">
-          <div className="flex items-center justify-center mb-4">
-            <FaEnvelope className="text-2xl text-[#38BDF8] dark:text-cyan-400 mr-3" />
-            <span className="text-lg dark:text-gray-200">support@refixly.com</span>
-          </div>
+
           <p className="text-[#94A3B8] dark:text-gray-300 mb-6">
             We typically respond within 24 hours
           </p>

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -145,6 +145,7 @@ const Footer = () => {
           <div className="flex flex-col md:flex-row justify-between items-center space-y-2 md:space-y-0">
             <div className="text-center md:text-left text-xs text-gray-500 dark:text-gray-400">
               <p>© {currentYear} Refixly. Made with ❤️ All rights reserved.</p>
+              <p className="mt-1">Contact us: <a href="mailto:support@refixly.com" className="underline">support@refixly.com</a></p>
             </div>
             <div className="flex items-center space-x-4 text-xs">
               <Link


### PR DESCRIPTION
# 🛠️ Pull Request Template

Removed the duplicate contact email (support@refixly.com) from the Contact page and added it to the Footer so that the email is displayed only once across the site.
This improves clarity, avoids redundancy, and makes the footer the single source of truth for contact information.

Describe the changes you made and the purpose of this pull request.

---

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have linked the related issue using `Fixes #issue_no`

---

## 📎 Related Issue

Fixes #79
