### PR TITLE
fix: saved tutorials now correctly show as saved after re-render

### DIFF
--- a/client/src/Pages/Tutorial.jsx
+++ b/client/src/Pages/Tutorial.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import NavBar from "../components/NavBar";
 import { Loader, Bookmark, FileQuestion, XCircle, Filter } from "lucide-react";
 import toast from "react-hot-toast";
@@ -28,7 +28,7 @@ const Tutorial = () => {
     const storedSearchHistory = localStorage.getItem("searchHistory");
     const storedRecentlyViewed = localStorage.getItem("recentlyViewed");
     const storedBookmarkedTutorials = localStorage.getItem(
-      "bookmarkedTutorials"
+      "refixly_savedTutorials"
     );
     if (storedSearchHistory) setSearchHistory(JSON.parse(storedSearchHistory));
     if (storedRecentlyViewed)

--- a/client/src/Pages/TutorialsPage.jsx
+++ b/client/src/Pages/TutorialsPage.jsx
@@ -64,7 +64,7 @@ const TutorialsPage = () => {
     }
 
     const updatedSaved = [tutorialToSave, ...saved];
-    localStorage.setItem('refixly_savedTutorials', JSON.stringify(updatedSaved));
+    localStorage.setItem('bookmarkedTutorials', JSON.stringify(updatedSaved));
     setSavedTutorials(updatedSaved);
     toast.success('Tutorial saved!');
   };

--- a/client/src/components/AIDamageDetection.jsx
+++ b/client/src/components/AIDamageDetection.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState ,useCallback} from "react";
 import axios from "axios";
 import AIResponseSection from "./AIResponseSection";
 


### PR DESCRIPTION
# 🛠️ Pull Request

## 📄 Description

PR fixes a bug where tutorials saved by the user were not correctly marked as saved when returning to the search page upon re rendering.

---

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors

---

## 📎 Related Issue

Fixes #97 
