### PR TITLE
Irrelevant get started section removed

### DIFF
--- a/client/src/Pages/Home.jsx
+++ b/client/src/Pages/Home.jsx
@@ -256,22 +256,6 @@ const UserHome = () => {
         <HomeFAQ faqs={faqs} darkMode={true} />
       </section>
 
-      {/* CTA */}
-      <section className="py-20 px-6 bg-gradient-to-b from-[#1E293B] to-[#0F172A] dark:from-gray-800 dark:to-gray-900 text-center">
-        <div className="max-w-3xl mx-auto">
-          <h3 className="text-4xl font-bold mb-6 text-white dark:text-gray-200">Ready to start fixing smarter?</h3>
-          <p className="text-xl text-[#94A3B8] dark:text-gray-400 mb-10 max-w-2xl mx-auto">
-            Join thousands of users who trust Refixly to guide their DIY repair journeys.
-          </p>
-          <button 
-            className="bg-[#38BDF8] dark:bg-blue-400 text-white font-semibold px-10 py-4 rounded-full hover:bg-[#0EA5E9] dark:hover:bg-blue-500 transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
-            onClick={() => navigate('/signup')}
-          >
-            Get Started Now
-          </button>
-        </div>
-      </section>
-
     </div>
   );
 };


### PR DESCRIPTION
📄 Description
Fixes: #105

This PR addresses a user experience issue where authenticated users were incorrectly shown the "Get Started" section meant for new, unauthenticated users. After successful login, users were being redirected back to the login page when clicking the "Get Started" button, creating a redundant and confusing experience.

Changes Made:
Removed "Get Started" button from the home page for logged-in users

## ✅ Checklist

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [✅ ] I have commented my code where necessary
- [✅] I have made corresponding changes to the documentation
- [✅ ] My changes generate no new warnings or errors
- [ ✅=] I have linked the related issue using `Fixes #issue_no`

---

## 📎 Related Issue
https://github.com/Bavanetha27/Refixly/issues/105

## Screenshot 
<img width="1920" height="902" alt="image" src="https://github.com/user-attachments/assets/84752ae4-4aa6-43b1-9327-67e3e39f70c3" />
